### PR TITLE
Using scripts. Fix port variable name

### DIFF
--- a/using-scripts/solution/blueprint/tomcat-scripts/configure-tomcat.sh
+++ b/using-scripts/solution/blueprint/tomcat-scripts/configure-tomcat.sh
@@ -4,7 +4,7 @@ currHostName=`hostname`
 currFilename=$(basename "$0")
 
 newPort=$(ctx node properties port)
-ctx logger info "${currHostName}:${currFilename} :newPort ${port}"
+ctx logger info "${currHostName}:${currFilename} :newPort ${newPort}"
 
 war_url=$(ctx node properties war_url)
 ctx logger info "${currHostName}:${currFilename} :war_url ${war_url}"


### PR DESCRIPTION
In this PR, the port number variable name is fixed in a script in the `using-scripts` example.
